### PR TITLE
Fix movement and rotation bugs

### DIFF
--- a/src/main/java/com/jordan/blockstacker/Display.java
+++ b/src/main/java/com/jordan/blockstacker/Display.java
@@ -43,9 +43,9 @@ public class Display extends JPanel {
             @Override
             public void keyPressed(KeyEvent e) {
                 if (e.getKeyChar() == 'a') {
-                    scene.step(new MyVector(-1, 0));
+                    scene.moveActiveShapes(new MyVector(-1, 0));
                 } else if (e.getKeyChar() == 'd') {
-                    scene.step(new MyVector(1, 0));
+                    scene.moveActiveShapes(new MyVector(1, 0));
                 } else if (e.getKeyChar() == 's') {
                     scene.step(new MyVector(0, 1));
                 } else if (e.getKeyChar() == 'q') {

--- a/src/main/java/com/jordan/blockstacker/Scene.java
+++ b/src/main/java/com/jordan/blockstacker/Scene.java
@@ -79,6 +79,15 @@ public class Scene {
         }
     }
 
+    public void moveActiveShapes(MyVector movement) {
+        for (int i = 0; i < activeShapes.size(); i++) {
+            Shape shape = activeShapes.get(i);
+            if (shapeCanMove(shape, movement)) {
+                shape.move(movement);
+            }
+        }
+    }
+
     /**
      * Rotates all the active shapes.
      * */
@@ -106,18 +115,21 @@ public class Scene {
 
         // Check if the future locations are valid
         for (MyVector potentialLocation : futureLocations) {
-            if (potentialLocation.x >= blocksPerDim || potentialLocation.y >= blocksPerDim ||
-                potentialLocation.x < 0 || potentialLocation.y < 0) {
+            MyVector roundedLocation = new MyVector(Math.round(potentialLocation.x), Math.round(potentialLocation.y));
+            if (roundedLocation.x >= blocksPerDim || roundedLocation.y >= blocksPerDim ||
+                roundedLocation.x < 0 || roundedLocation.y < 0) {
                 return; // Invalid rotation, so do nothing
             }
-            if (allBlocks[(int) potentialLocation.x][(int) potentialLocation.y] != null) {
+            if (allBlocks[(int) roundedLocation.x][(int) roundedLocation.y] != null) {
                 return; // Collision with existing block, so do nothing
             }
         }
 
         // If we get here, the rotation is valid. Apply it.
         for (int i = 0; i < blocks.length; i++) {
-            blocks[i].location.set(futureLocations[i]);
+            MyVector potentialLocation = futureLocations[i];
+            MyVector roundedLocation = new MyVector(Math.round(potentialLocation.x), Math.round(potentialLocation.y));
+            blocks[i].location.set(roundedLocation);
         }
     }
 

--- a/src/test/java/com/jordan/blockstacker/SceneTest.java
+++ b/src/test/java/com/jordan/blockstacker/SceneTest.java
@@ -274,6 +274,26 @@ public class SceneTest {
             // The T-shape has a block at (3,1). A downward move (0,1) would cause a collision at (3,2).
             assertFalse(scene.shapeCanMove(activeShape, new MyVector(0, 1)), "Shape should not be able to move into an occupied cell.");
         }
+
+        @Test
+        @DisplayName("should not lock the piece when a horizontal move is invalid")
+        void testInvalidHorizontalMoveDoesNotLockPiece() {
+            // A T-Block at (3,0) has its rightmost block at x=4.
+            // Move it 5 times to the right, so its rightmost block is at x=9.
+            activeShape.move(5, 0); // location is now (8,0)
+            assertEquals(8, activeShape.location.x);
+
+            // The next horizontal move is invalid.
+            assertFalse(scene.shapeCanMove(activeShape, new MyVector(1, 0)));
+
+            // Call the horizontal move method
+            scene.moveActiveShapes(new MyVector(1, 0));
+
+            // Assert that the shape is still the same, not static, and at the same location.
+            assertEquals(1, scene.getActiveShapes().size(), "Should still only be one active shape.");
+            assertFalse(scene.getActiveShapes().get(0).isStatic(), "Shape should not be static.");
+            assertEquals(8, scene.getActiveShapes().get(0).location.x, "Shape should not have moved.");
+        }
     }
 
     @Nested
@@ -416,6 +436,21 @@ public class SceneTest {
                 assertEquals(originalPositions[i].x, rotatedBlocks[i].location.x, "Block x position should not change");
                 assertEquals(originalPositions[i].y, rotatedBlocks[i].location.y, "Block y position should not change");
             }
+        }
+
+        @Test
+        @DisplayName("should not crash when rotating at the edge due to float precision")
+        void testRotationAtEdgeDoesNotCrash() {
+            // Place a shape at the far right edge. A T-block at (8,1) has its rightmost part at x=9.
+            // We need to re-initialize the scene and shape to ensure a clean state for this test.
+            scene = new Scene(500, 500, GRID_SIZE);
+            activeShape = scene.getActiveShapes().get(0);
+            activeShape.move(new MyVector(5, 1)); // T-shape starts at (3,0), move to (8,1).
+
+            // With the rounding fix, this should not throw an exception.
+            assertDoesNotThrow(() -> {
+                scene.rotateActiveShapes();
+            }, "Rotation at the edge should not throw an exception.");
         }
     }
 


### PR DESCRIPTION
This commit addresses two bugs:
1. A movement bug where a block would stick to the side of the screen if the player attempted an invalid horizontal move. This was caused by the horizontal movement logic incorrectly locking the piece. A new method, `moveActiveShapes`, was introduced to handle horizontal movement without this side effect.

2. A rotation bug that could cause an `ArrayIndexOutOfBoundsException` when rotating a shape near the edge of the screen. This was due to floating-point inaccuracies. The fix introduces rounding to the calculated coordinates before performing boundary checks.

Additionally, new unit tests have been added to `SceneTest.java` to verify both fixes and prevent regressions.